### PR TITLE
Worked on scope for top 5 avg ratings

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -4,7 +4,10 @@ class ReviewsController < OpenReadController
   # GET /reviews
   def index
     @reviews = Review.all
-
+    @reviews = Review.where(nil) # creates an anonymous scope
+    filtering_params(params).each do |key, value|
+      @reviews = @reviews.public_send("filter_by_#{key}", value) if value.present?
+    end
     render json: @reviews
   end
 
@@ -44,6 +47,9 @@ class ReviewsController < OpenReadController
       @review = Review.find(params[:id])
     end
 
+    def filtering_params(params)
+      params.slice(:rating)
+    end
     # Only allow a trusted parameter "white list" through.
     def review_params
       params.require(:review).permit(:rating, :note, :wifi, :bathroom, :food,

--- a/app/controllers/work_spaces_controller.rb
+++ b/app/controllers/work_spaces_controller.rb
@@ -46,6 +46,6 @@ class WorkSpacesController < OpenReadController
 
     # Only allow a trusted parameter "white list" through.
     def work_space_params
-      params.require(:work_space).permit(:place_id, :lat, :lng, :user_id)
+      params.require(:work_space).permit(:place_id, :lat, :lng, :user_id, :avg_rating)
     end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -3,4 +3,36 @@
 class Review < ApplicationRecord
   belongs_to :work_space
   belongs_to :user
+
+  scope :filter_by_rating, -> { where('rating > 2')}
+  # scope :filter_by_rating, ->(rating) { where rating: rating }
+  def top_review_rating
+    # WorkSpace.left_joins(:reviews).group(:id).order('COUNT(reviews.id) ASC').limit(3)
+    # WorkSpace.find_by reviews.order(rating: :desc).limit(2)
+    # Review.joins(:work_space).where(reviews: { rating: 5 })
+    Review.filter_by_rating.first(2)
+  end
+  # def count
+  #   Review.count(:rating)
+  #   # Review.group(:work_space).count(:rating)
+  # end
+  #
+  # def average
+  #   Review.average(:rating).to_i
+  # end
+  #
+  # def bool
+  #   if ((Review.where(rating: 0).pluck(:rating).length.to_f /
+  #   count.to_f * 100).to_i) > 25
+  #     false
+  #   else
+  #     true
+  #   end
+  # end
+
+  # def count_review
+  #   Review.distinct(:rating)
+  #   # WorkSpace.count(:all)
+  #   # WorkSpace.select("work_spaces.*, COUNT(reviews.id) as review_count").joins("LEFT OUTER JOIN reviews ON (reviews.work_space_id = work_spaces.id)").group("work_spaces.id")
+  # end
 end

--- a/app/models/work_space.rb
+++ b/app/models/work_space.rb
@@ -2,42 +2,63 @@ class WorkSpace < ApplicationRecord
   belongs_to :user
   has_many :reviews, dependent: :delete_all
 
+  # scope :max_rating, -> (rating) { joins(:reviews).group("work_spaces.id").where("rating > ?", rating) if rating }
+  scope :max_rating, ->(rating) { joins(:reviews)
+    .group("work_spaces.id")
+    .order('AVG(reviews.rating) desc')
+    .having('AVG(reviews.rating) > ?', rating) if rating }
   # Count all reviews
+  def top_avg_rating
+    # WorkSpace.left_joins(:reviews).group(:id).order('COUNT(reviews.id) ASC').limit(3)
+    # WorkSpace.find_by reviews.order(rating: :desc).limit(2)
+    # WorkSpace.joins(:reviews).where(reviews: { rating: 5 })
+    # WorkSpace.where('avg_rating > 3')
+    WorkSpace.max_rating(2).limit(5)
+  end
+
   def count_reviews
     reviews.size
   end
 
   # Averages for attributes
   def avg_rating
-    reviews.average(:rating).round(2)
+    reviews.average(:rating).to_f
   end
 
   def avg_noise
-    reviews.average(:noise).round(2)
+    reviews.average(:noise).to_f
   end
 
   def avg_wifi
-    reviews.average(:wifi).round(2)
+    reviews.average(:wifi).to_f
   end
 
   def avg_bathroom
-    reviews.average(:bathroom).round(2)
+    reviews.average(:bathroom).to_f
   end
 
   def avg_food
-    reviews.average(:food).round(2)
+    reviews.average(:food).to_f
   end
 
   def avg_coffee
-    reviews.average(:coffee).round(2)
+    reviews.average(:coffee).to_f
   end
 
   def avg_seating
-    reviews.average(:seating).round(2)
+    reviews.average(:seating).to_f
   end
 
   def avg_outlet
-    reviews.average(:outlet).round(2)
+    reviews.average(:outlet).to_f
+  end
+
+  def top_rating
+    reviews.order(rating: :desc).limit(2)
+  end
+
+  def top_bathroom
+    reviews.order(bathroom: :desc).limit(2)
   end
 
   # Booleans for attributes

--- a/app/serializers/review_serializer.rb
+++ b/app/serializers/review_serializer.rb
@@ -8,7 +8,8 @@ class ReviewSerializer < ActiveModel::Serializer
              :noise,
              :coffee,
              :seating,
-             :user
+             :user,
+             :top_review_rating
   has_one :user
   has_one :work_space
 end

--- a/app/serializers/work_space_serializer.rb
+++ b/app/serializers/work_space_serializer.rb
@@ -19,7 +19,10 @@ class WorkSpaceSerializer < ActiveModel::Serializer
              :bool_coffee,
              :bool_food,
              :bool_bathroom,
-             :bool_wifi
+             :bool_wifi,
+             :top_rating,
+             :top_bathroom,
+             :top_avg_rating
   has_one :user
   has_many :reviews
 end


### PR DESCRIPTION
Merging to this branch for now. 

Had to change .count(2) Seems to not work well when fields are empty. ".to_f" is working. Maybe we can round in the client until we figure this one out. 

Was able to use scope to retrieve top workspaces by their average rating 