### PR TITLE
Add outlet to review serializer

### DIFF
--- a/app/serializers/review_serializer.rb
+++ b/app/serializers/review_serializer.rb
@@ -15,6 +15,7 @@ class ReviewSerializer < ActiveModel::Serializer
              :parking,
              :meetingspace,
              :outdoorspace,
+             :outlet,
              :user,
              :work_space,
              :created_at,


### PR DESCRIPTION
noticed serializer was missing `outlet` when working to display checkboxes on update-review. I think this is the only change needed? Tested and works on my computer.