### PR TITLE
Added case_sensitive => false to username validation

### DIFF
--- a/app/models/concerns/authentication.rb
+++ b/app/models/concerns/authentication.rb
@@ -20,7 +20,7 @@ module Authentication
     after_find :fix_up_token
     validates :email, uniqueness: true
     validates :email, presence: true
-    validates :username, uniqueness: true
+    validates :username, uniqueness: { case_sensitive: false }
     validates :username, presence: true
     validates :username, format: { with: /\A[a-zA-Z0-9]+\z/,
                                    message: 'only allows letters and numbers' }


### PR DESCRIPTION
This change will prevent users from creating usernames that are only different based on case sensitivity. (i.e if "Jenny" is a username already a new user cannot create "jenny".

This will be important as the UX team requested no case sensitivity in the signin form.

 